### PR TITLE
[ONME-2528] Eth driver polling for link status enabled.

### DIFF
--- a/sal-nanostack-driver-k64f-eth/k64f_eth_nanostack_port.h
+++ b/sal-nanostack-driver-k64f-eth/k64f_eth_nanostack_port.h
@@ -34,6 +34,7 @@ extern "C" {
 #endif
 
 extern void arm_eth_phy_device_register(uint8_t *mac_ptr, void (*app_ipv6_init_cb)(uint8_t, int8_t));
+extern int8_t k64f_eth_phy_up();
 
 #ifdef __cplusplus
 }

--- a/source/fsl_enet_driver.c
+++ b/source/fsl_enet_driver.c
@@ -102,7 +102,7 @@ uint32_t enet_mii_read(uint32_t instance, uint32_t phyAddr, uint32_t phyReg, uin
         {
             break;
         }
-        wait_ms(1);
+        wait_ms(0.1);
     }
 
     /* Check for timeout*/


### PR DESCRIPTION
In order to meet Thread related requirement, we set a polling function which
polls for the phy link status. Unfortunately we cannot map an interrupt from eth phy
layer as the pinouts are not soldered in the evaluation platform.

@SeppoTakalo @TuomoHautamaki  @artokin 
