### PR TITLE
[ONME-2550] Driver waits for the TX buffer descriptor queue to be emptied

### DIFF
--- a/sal-nanostack-driver-k64f-eth/k64f_eth_nanostack_port.h
+++ b/sal-nanostack-driver-k64f-eth/k64f_eth_nanostack_port.h
@@ -7,7 +7,7 @@
 
 #define ENET_HDR_LEN                  (14)
 #define ENET_RX_RING_LEN              (8)
-#define ENET_TX_RING_LEN              (2)
+#define ENET_TX_RING_LEN              (4)
 #define ENET_RX_LARGE_BUFFER_NUM      (0)
 #define ENET_RX_BUFFER_ALIGNMENT      (16)
 #define ENET_TX_BUFFER_ALIGNMENT      (16)

--- a/source/k64f_eth_nanostack_port.c
+++ b/source/k64f_eth_nanostack_port.c
@@ -432,12 +432,9 @@ static int8_t k64f_eth_send(uint8_t *data_ptr, uint16_t data_len)
     }
 
     /* Check if there are any buffer descriptors free */
-   descriptor_num = k64f_tx_descriptors_ready(buf_desc_ring);
-
-    if (descriptor_num < 1) {
-        tr_error("TX buf descriptors full. Can't queue packet.");
-        return -1;
-    }
+   do {
+       descriptor_num = k64f_tx_descriptors_ready(buf_desc_ring);
+   } while (descriptor_num<1);
 
     uint8_t *buf_ptr = MEM_ALLOC(data_len + TX_BUF_ALIGNMENT);
     if (!buf_ptr) {


### PR DESCRIPTION
Number of TX descriptors is increased from 2 to 4 and logic is changed
so as to facilitate the TX routine so as to wait for the previous transmission to complete.
