### PR TITLE
Replace deprecated/removed Semaphore.wait usage

### DIFF
--- a/source/NanostackEthernetPhyK64F.cpp
+++ b/source/NanostackEthernetPhyK64F.cpp
@@ -22,7 +22,7 @@ NanostackEthernetPhyK64F::NanostackEthernetPhyK64F()
 int8_t NanostackEthernetPhyK64F::phy_register()
 {
     arm_eth_phy_device_register(_mac, driver_status_cb);
-    enet_sem.wait();
+    enet_sem.acquire();
     return iface_id;
 }
 


### PR DESCRIPTION
wait method is replaced by acquire in Mbed OS Semaphore API.